### PR TITLE
cmsis: don't wrap cache header file with cache macroes

### DIFF
--- a/CMSIS/Core/Include/core_cm7.h
+++ b/CMSIS/Core/Include/core_cm7.h
@@ -2229,10 +2229,7 @@ __STATIC_INLINE uint32_t SCB_GetFPUType(void)
 
 /* ##########################  Cache functions  #################################### */
 
-#if ((defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)) || \
-     (defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)))
 #include "cachel1_armv7.h"
-#endif
 
 
 /* ##################################    SysTick function  ############################################ */


### PR DESCRIPTION
this is not necessary.
the bodies of functions inside are wrapped with cache macroes already.
there will be build error that cache APIs are not defined with cache
macroes undefined

Signed-off-by: Dong Wang <dong.d.wang@intel.com>